### PR TITLE
Refactor/triplegen abstract

### DIFF
--- a/src/sparnatural/components/builder-section/groupwrapper/criteriagroup/edit-components/widgets/AbstractWidget.ts
+++ b/src/sparnatural/components/builder-section/groupwrapper/criteriagroup/edit-components/widgets/AbstractWidget.ts
@@ -22,6 +22,9 @@ export abstract class AbstractWidget extends HTMLComponent {
   startClassVal: SelectedVal;
   objectPropVal: SelectedVal;
   endClassVal: SelectedVal;
+  protected blockStartTriple = false;
+  protected blockObjectPropTriple = false;
+  protected blockEndTriple = false;
   constructor(
     baseCssClass: string,
     parentComponent: HTMLComponent,
@@ -56,6 +59,7 @@ export abstract class AbstractWidget extends HTMLComponent {
     return this.widgetValues;
   }
 
+
   // Sparnatural stores the variable name always with the questionmark. 
   // for the DataFactory from "n3" lib we need the variable name without '?'
   getVariableValue(selectedVal: SelectedVal): string {
@@ -77,5 +81,15 @@ export abstract class AbstractWidget extends HTMLComponent {
     this.html[0].dispatchEvent(
       new CustomEvent("renderWidgetVal", { bubbles: true, detail: widgetValue })
     );
+  }
+
+  getblockStartTriple() {
+    return this.blockStartTriple
+  }
+  getBlockObjectPropTiple() {
+    return this.blockObjectPropTriple
+  }
+  getBlockEndTriple() {
+    return this.blockEndTriple
   }
 }

--- a/src/sparnatural/components/builder-section/groupwrapper/criteriagroup/edit-components/widgets/MapWidget.ts
+++ b/src/sparnatural/components/builder-section/groupwrapper/criteriagroup/edit-components/widgets/MapWidget.ts
@@ -30,6 +30,7 @@ export interface MapWidgetValue extends WidgetValue {
 
 export default class MapWidget extends AbstractWidget {
   protected widgetValues: MapWidgetValue[];
+  protected blockObjectPropTriple: boolean = true
   renderMapValueBtn: AddUserInputBtn;
   map: L.Map;
   drawingLayer: L.Layer;

--- a/src/sparnatural/sparql/RdfJsQuery.ts
+++ b/src/sparnatural/sparql/RdfJsQuery.ts
@@ -109,11 +109,11 @@ export default class RdfJsGenerator {
     const ptrns: Pattern[] = [];    
     //get the infromation from the widget if there are widgetvalues selected
     let rdfPattern: Pattern[] = [];
-
-    let triples = this.#buildCrtGrpTriples(grpWrapper.CriteriaGroup,isChild);
-
     const widgetComponent:AbstractWidget | null | undefined = grpWrapper.CriteriaGroup.EndClassGroup?.editComponents?.widgetWrapper?.widgetComponent
-    if (widgetComponent.getwidgetValues()?.length > 0 ) rdfPattern = widgetComponent.getRdfJsPattern();
+
+    let triples = this.#buildCrtGrpTriples(grpWrapper.CriteriaGroup,widgetComponent,isChild);
+
+    if (widgetComponent?.getwidgetValues()?.length > 0 ) rdfPattern = widgetComponent.getRdfJsPattern();
     
     const hasOption =
       grpWrapper.optionState == OptionTypes.OPTIONAL ||
@@ -183,38 +183,45 @@ export default class RdfJsGenerator {
   }
 
   // Writes The default triples 
-  #buildCrtGrpTriples(crtGrp: CriteriaGroup,isChild: boolean): Triple[] {
+  #buildCrtGrpTriples(crtGrp: CriteriaGroup,widgeComponent:AbstractWidget,isChild: boolean): Triple[] {
     let triples: Triple[] = [];
-    let startClass = this.#buildTypeTripple(
-      crtGrp.StartClassGroup.getVarName(),
-      RDF.TYPE.value,
-      crtGrp.StartClassGroup.getTypeSelected()
-    );
-   
-      let endClass = this.#buildTypeTripple(
+
+    // startClassTriple
+    let startClass
+    if(!widgeComponent?.getblockStartTriple())
+      startClass = this.#buildTypeTripple(
+        crtGrp.StartClassGroup.getVarName(),
+        RDF.TYPE.value,
+        crtGrp.StartClassGroup.getTypeSelected()
+      );
+      if(!isChild && startClass){
+        // if it is a child branch (WHERE or AND) then don't create startClass triple. It's already done in the parent
+        triples.push(startClass)
+      }
+    
+
+    // endClassTriple
+    let endClass
+    if(!widgeComponent?.getBlockEndTriple())
+      endClass = this.#buildTypeTripple(
         crtGrp.EndClassGroup.getVarName(),
         RDF.TYPE.value,
         crtGrp.EndClassGroup.getTypeSelected()
       );
+      if(!this.specProvider.isLiteralClass(crtGrp.EndClassGroup?.getTypeSelected()) && endClass){
+        // If it is a literal class then it doesn't have the endclass Tiple.
+        // see: http://data.sparna.fr/ontologies/sparnatural-config-core/index-en.html#http://www.w3.org/2000/01/rdf-schema#Literal
+        triples.push(endClass)
+      }
     
-    let connectingTripple = this.#buildIntersectionTriple(
-      startClass?.subject as Variable,
-      crtGrp.ObjectPropertyGroup.getTypeSelected(),
-      endClass?.subject as Variable
-    );
 
-      // always 
-
-    if(!isChild && startClass){
-      // if it is a child branch (WHERE or AND) then don't create startClass triple. It's already done in the parent
-      triples.push(startClass)
-    }
-
-    if(!this.specProvider.isLiteralClass(crtGrp.EndClassGroup.getTypeSelected()) && endClass){
-      // If it is a literal class then it doesn't have the endclass Tiple.
-      // see: http://data.sparna.fr/ontologies/sparnatural-config-core/index-en.html#http://www.w3.org/2000/01/rdf-schema#Literal
-      triples.push(endClass)
-    }
+    let connectingTripple
+    if(!widgeComponent?.getBlockObjectPropTiple())
+      connectingTripple = this.#buildIntersectionTriple(
+        startClass?.subject as Variable,
+        crtGrp.ObjectPropertyGroup.getTypeSelected(),
+        endClass?.subject as Variable
+      );
 
     if(connectingTripple) triples.push(connectingTripple)
    

--- a/src/sparnatural/sparql/RdfJsQuery.ts
+++ b/src/sparnatural/sparql/RdfJsQuery.ts
@@ -19,6 +19,7 @@ import Sparnatural from "../components/Sparnatural";
 import CriteriaGroup from "../components/builder-section/groupwrapper/criteriagroup/CriteriaGroup";
 import { DataFactory } from "n3";
 import { RDF } from "../spec-providers/RDFSpecificationProvider";
+import { AbstractWidget } from "../components/builder-section/groupwrapper/criteriagroup/edit-components/widgets/AbstractWidget";
 /*
   Reads out the UI and creates the and sparqljs pattern. 
   sparqljs pattern builds pattern structure on top of rdfjs datamodel. see:https://rdf.js.org/data-model-spec/
@@ -105,30 +106,27 @@ export default class RdfJsGenerator {
 
   // this method traverses through the groupwrappers and retrieves the information from each widget.
   #processGrpWrapper(grpWrapper: GroupWrapper, isInOption: boolean, isChild: boolean) {
-    let ptrns: Pattern[] = [];
-
-    let triples = this.#buildCrtGrpTriples(grpWrapper.CriteriaGroup,isChild);
+    const ptrns: Pattern[] = [];    
     //get the infromation from the widget if there are widgetvalues selected
     let rdfPattern: Pattern[] = [];
-    if (
-      grpWrapper.CriteriaGroup.EndClassGroup.editComponents?.widgetWrapper?.widgetComponent?.getwidgetValues()
-        ?.length > 0
-    ) {
-      rdfPattern =
-        grpWrapper.CriteriaGroup.EndClassGroup.editComponents.widgetWrapper.widgetComponent.getRdfJsPattern();
-    }
-    let hasOption =
+
+    let triples = this.#buildCrtGrpTriples(grpWrapper.CriteriaGroup,isChild);
+
+    const widgetComponent:AbstractWidget | null | undefined = grpWrapper.CriteriaGroup.EndClassGroup?.editComponents?.widgetWrapper?.widgetComponent
+    if (widgetComponent.getwidgetValues()?.length > 0 ) rdfPattern = widgetComponent.getRdfJsPattern();
+    
+    const hasOption =
       grpWrapper.optionState == OptionTypes.OPTIONAL ||
       grpWrapper.optionState == OptionTypes.NOTEXISTS
         ? true
         : false;
     // if it has whereChild
-    let wherePtrn = grpWrapper.whereChild
+    const wherePtrn = grpWrapper.whereChild
       ? this.#processGrpWrapper(grpWrapper.whereChild, hasOption, true)
       : null;
 
     // if it hasandSiblings
-    let andPtrn = grpWrapper.andSibling
+    const andPtrn = grpWrapper.andSibling
       ? this.#processGrpWrapper(grpWrapper.andSibling, hasOption, true)
       : null;
 
@@ -184,6 +182,7 @@ export default class RdfJsGenerator {
     return ptrn
   }
 
+  // Writes The default triples 
   #buildCrtGrpTriples(crtGrp: CriteriaGroup,isChild: boolean): Triple[] {
     let triples: Triple[] = [];
     let startClass = this.#buildTypeTripple(


### PR DESCRIPTION
@tfrancart fixing the problem with unwanted generation of the object property triple. It doesn't solve the original discussion we had in #83 but it at least solves the two issues for now. 

The behavior is as following. The Widget can block the generation of a triple. But if the startclasstriple/endclasstriple is blocked it will also block the predicate triple since it builds on the startclass/endclass triple