### PR TITLE
add working example

### DIFF
--- a/src/sparnatural/components/builder-section/groupwrapper/criteriagroup/startendclassgroup/EndClassGroup.ts
+++ b/src/sparnatural/components/builder-section/groupwrapper/criteriagroup/startendclassgroup/EndClassGroup.ts
@@ -88,9 +88,11 @@ class EndClassGroup extends HTMLComponent {
   // see: https://docs.sparnatural.eu/OWL-based-configuration#classes-configuration-reference
   #addDefaultLblVar(type:string,varName:string) {
     const lbl = this.specProvider.getDefaultLabelProperty(type)
+
     if(lbl) {
+      const varName = this.specProvider.readDefaultLblVar(lbl)
+      varName ? this.defaultLblVar.variable = `?${varName}` : this.defaultLblVar.variable = `${this.getVarName()}_label`
       this.defaultLblVar.type = lbl
-      this.defaultLblVar.variable = `${varName}_label`
     }
   }
 

--- a/src/sparnatural/components/builder-section/groupwrapper/criteriagroup/startendclassgroup/StartClassGroup.ts
+++ b/src/sparnatural/components/builder-section/groupwrapper/criteriagroup/startendclassgroup/StartClassGroup.ts
@@ -87,9 +87,11 @@ class StartClassGroup extends HTMLComponent {
   // see: https://docs.sparnatural.eu/OWL-based-configuration#classes-configuration-reference
   #addDefaultLblVar(type:string,varName:string) {
     const lbl = this.specProvider.getDefaultLabelProperty(type)
+
     if(lbl) {
+      const varName = this.specProvider.readDefaultLblVar(lbl)
+      varName ? this.defaultLblVar.variable = `?${varName}` : this.defaultLblVar.variable = `${this.getVarName()}_label`
       this.defaultLblVar.type = lbl
-      this.defaultLblVar.variable = `${varName}_label`
     }
   }
 

--- a/src/sparnatural/components/widgets/MapWidget.ts
+++ b/src/sparnatural/components/widgets/MapWidget.ts
@@ -166,16 +166,8 @@ export default class MapWidget extends AbstractWidget {
   // reference: https://graphdb.ontotext.com/documentation/standard/geosparql-support.html
   getRdfJsPattern(): Pattern[] {
 
-    let geomA: Triple = SparqlFactory.buildTriple(
-      DataFactory.variable(this.getVariableValue(this.startClassVal)),
-      DataFactory.namedNode(
-        "http://www.opengis.net/ont/geosparql#hasGeometry"
-      ),
-      DataFactory.variable("geomA")
-    );
-
     let asWKT: Triple = SparqlFactory.buildTriple(
-      DataFactory.variable(geomA.object.value),
+      DataFactory.variable(this.getVariableValue(this.startClassVal)),
       DataFactory.namedNode("http://www.opengis.net/ont/geosparql#asWKT"),
       DataFactory.variable("aWKT")
     );
@@ -203,7 +195,7 @@ export default class MapWidget extends AbstractWidget {
 
     let ptrn: BgpPattern = {
       type: "bgp",
-      triples: [geomA, asWKT],
+      triples: [asWKT],
     };
 
 

--- a/src/sparnatural/generators/RdfJsQuery.ts
+++ b/src/sparnatural/generators/RdfJsQuery.ts
@@ -3,7 +3,6 @@ import { Language, Order } from "./ISparJson";
 import { OptionTypes } from "../components/builder-section/groupwrapper/criteriagroup/optionsgroup/OptionsGroup";
 import ISpecProvider from "../spec-providers/ISpecProviders";
 import {
-  GroupPattern,
   IriTerm,
   OptionalPattern,
   Ordering,
@@ -120,8 +119,6 @@ export default class RdfJsGenerator {
     const andPtrn = grpWrapper.andSibling
       ? this.#processGrpWrapper(grpWrapper.andSibling, false, true)
       : null;
-
-       
    
     const widgetComponent:AbstractWidget | null | undefined = grpWrapper.CriteriaGroup.EndClassGroup?.editComponents?.widgetWrapper?.widgetComponent
     //get the infromation from the widget if there are widgetvalues selected

--- a/src/sparnatural/spec-providers/ISpecProviders.ts
+++ b/src/sparnatural/spec-providers/ISpecProviders.ts
@@ -22,5 +22,6 @@ interface ISpecProvider {
   getBeginDateProperty(propertyId: string): string;
   getEndDateProperty(propertyId: string): string;
   getExactDateProperty(propertyId: string): string;
+  readDefaultLblVar(propertyId:string):string;
 }
 export default ISpecProvider;

--- a/src/sparnatural/spec-providers/JsonLdSpecificationProvider.ts
+++ b/src/sparnatural/spec-providers/JsonLdSpecificationProvider.ts
@@ -394,6 +394,11 @@ export default class JsonLdSpecificationProvider implements ISpecProvider {
     return sparql;
   };
 
+  readDefaultLblVar(uri:string){
+    const ressource = this._getResourceById(uri)
+    return ressource?.varName
+  }
+
   readRange = function (objectProperty: string) {
     var propertyEntity = this._getResourceById(objectProperty);
     if (propertyEntity != null) {

--- a/src/sparnatural/spec-providers/RDFSpecificationProvider.ts
+++ b/src/sparnatural/spec-providers/RDFSpecificationProvider.ts
@@ -465,6 +465,11 @@ export class RDFSpecificationProvider implements ISpecProvider {
     return this._readClassesInRangeOfProperty(propertyId);
   }
 
+  readDefaultLblVar(uri:string){
+    let ressource = this._readAsResource(uri, 'varName')
+    return ressource[0]
+  }
+
   _readDatasourceAnnotationProperty(
     propertyOrClassId: any,
     datasourceAnnotationProperty: any

--- a/static/default/configs/config.js
+++ b/static/default/configs/config.js
@@ -175,7 +175,9 @@ export default {
         { "@value": "Location", "@language": "en" },
         { "@value": "Location", "@language": "fr" },
       ],
-      faIcon: "fas fa-map-marked-alt"
+      faIcon: "fas fa-map-marked-alt",
+      defaultLabelProperty:
+      "http://www.opengis.net/ont/geosparql#asWKT",
     },
     {
       "@id": "http://labs.sparna.fr/sparnatural-demo-dbpedia/onto#Text",
@@ -250,7 +252,7 @@ export default {
     },
     {
       "@id":
-        "http://labs.sparna.fr/sparnatural-demo-dbpedia/onto#hasLocation",
+        "http://www.opengis.net/ont/geosparql#hasLocation",
       "@type": "ObjectProperty",
       subPropertyOf: "sparnatural:NonSelectableProperty",
       label: [
@@ -530,6 +532,20 @@ BIND(true AS ?hasChildren)
       ],
       enableOptional: true,
       sparqlString: "rdfs:label",
+      range: "http://labs.sparna.fr/sparnatural-demo-dbpedia/onto#Text",
+    },
+    {
+      "@id":
+        "http://www.opengis.net/ont/geosparql#asWKT",
+      "@type": "ObjectProperty",
+      subPropertyOf: "sparnatural:NonSelectableProperty",
+      label: [
+        { "@value": "name", "@language": "en" },
+        { "@value": "nom", "@language": "fr" },
+      ],
+      enableOptional: true,
+      varName: 'awkt',
+      sparqlString: "<http://www.opengis.net/ont/geosparql#asWKT>",
       range: "http://labs.sparna.fr/sparnatural-demo-dbpedia/onto#Text",
     },
     {


### PR DESCRIPTION
Hi @tfrancart, look at this PR. I added a config "varName" which can override the default SPARQL variable name of the default label property (?varname_label). I used it in my GEOSPARQL for the WKT literal. So i defined the WKT literal as the default label property and then i changed the variable name to '?asWKT'

What do you think of that?